### PR TITLE
fix: actualizar configuración de WebSocket para usar setAllowedOrigin…

### DIFF
--- a/src/main/java/org/arsw/maze_rush/config/WebSocketConfig.java
+++ b/src/main/java/org/arsw/maze_rush/config/WebSocketConfig.java
@@ -15,7 +15,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
-    @Value("${app.domain.front:*}")
+    @Value("${app.websocket.allowed-origins:http://localhost:3000,http://localhost:5173,https://maze-rush-frontend.vercel.app}")
     private String allowedOrigins;
 
     @Override
@@ -35,7 +35,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // Registra el endpoint WebSocket que los clientes usarán para conectarse
         registry.addEndpoint("/ws")
-                .setAllowedOrigins(allowedOrigins.split(","))
+                .setAllowedOriginPatterns(allowedOrigins.split(","))
                 .withSockJS(); // Fallback a SockJS para navegadores que no soportan WebSocket
     }
 }

--- a/src/test/java/org/arsw/maze_rush/config/WebSocketConfigTest.java
+++ b/src/test/java/org/arsw/maze_rush/config/WebSocketConfigTest.java
@@ -58,8 +58,8 @@ class WebSocketConfigTest {
         //  Cuando se llame a addEndpoint("/ws"), devolver el mock de registro
         when(stompEndpointRegistry.addEndpoint("/ws")).thenReturn(endpointRegistration);
         
-        // Cuando se llame a setAllowedOrigins(...), devolver el mismo mock de registro (para poder seguir encadenando)
-        when(endpointRegistration.setAllowedOrigins(any(String[].class))).thenReturn(endpointRegistration);
+        // Cuando se llame a setAllowedOriginPatterns(...), devolver el mismo mock de registro (para poder seguir encadenando)
+        when(endpointRegistration.setAllowedOriginPatterns(any(String[].class))).thenReturn(endpointRegistration);
 
         webSocketConfig.registerStompEndpoints(stompEndpointRegistry);
 
@@ -67,7 +67,7 @@ class WebSocketConfigTest {
         verify(stompEndpointRegistry).addEndpoint("/ws");
         
         // Verificamos que se pasaron los orígenes parseados correctamente (split por coma)
-        verify(endpointRegistration).setAllowedOrigins("http://localhost:3000", "http://example.com");
+        verify(endpointRegistration).setAllowedOriginPatterns("http://localhost:3000", "http://example.com");
         
         // Verificamos que se habilitó SockJS
         verify(endpointRegistration).withSockJS();


### PR DESCRIPTION
This pull request updates the WebSocket configuration to improve security and compatibility by refining how allowed origins are handled for WebSocket connections. The changes also update the corresponding unit tests to reflect these adjustments.

**WebSocket Configuration Updates:**

* Changed the configuration property from `app.domain.front` to `app.websocket.allowed-origins` and provided a default list of allowed origins, including local development and production frontend URLs in `WebSocketConfig.java`.
* Updated the WebSocket endpoint registration to use `setAllowedOriginPatterns` instead of `setAllowedOrigins`, allowing for pattern-based origin validation in `WebSocketConfig.java`.

**Test Adjustments:**

* Modified the unit test in `WebSocketConfigTest.java` to mock and verify the use of `setAllowedOriginPatterns` instead of `setAllowedOrigins`, ensuring the test aligns with the new configuration logic.…Patterns