### PR TITLE
fix: agregar origen permitido adicional en la configuración de WebSocket

### DIFF
--- a/src/main/java/org/arsw/maze_rush/config/WebSocketConfig.java
+++ b/src/main/java/org/arsw/maze_rush/config/WebSocketConfig.java
@@ -15,7 +15,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
-    @Value("${app.websocket.allowed-origins:http://localhost:3000,http://localhost:5173,https://maze-rush-frontend.vercel.app}")
+    @Value("${app.websocket.allowed-origins:http://localhost:3000,http://localhost:5173,https://maze-rush-frontend.vercel.app,https://maze-rush-frontend-production.up.railway.app}")
     private String allowedOrigins;
 
     @Override


### PR DESCRIPTION
This pull request makes a small configuration update to the WebSocket allowed origins. The change adds a new production frontend URL to the list of allowed origins, ensuring that WebSocket connections from this domain are accepted.

- Added `https://maze-rush-frontend-production.up.railway.app` to the `allowed-origins` in the `WebSocketConfig` class to support connections from the new production frontend.