### PR TITLE
Release 1.5.0

### DIFF
--- a/src/main/java/org/arsw/maze_rush/game/dto/GameFinishDTO.java
+++ b/src/main/java/org/arsw/maze_rush/game/dto/GameFinishDTO.java
@@ -13,11 +13,13 @@ import java.time.Instant;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GameFinishDTO {
+    private String type = "finish";
     private String username;
     private Long finishTime; // Tiempo en segundos
     private Instant timestamp;
     
     public GameFinishDTO(String username, Long finishTime) {
+        this.type = "finish";
         this.username = username;
         this.finishTime = finishTime;
         this.timestamp = Instant.now();

--- a/src/main/java/org/arsw/maze_rush/game/dto/GameMoveDTO.java
+++ b/src/main/java/org/arsw/maze_rush/game/dto/GameMoveDTO.java
@@ -13,11 +13,13 @@ import java.time.Instant;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GameMoveDTO {
+    private String type = "move";
     private String username;
     private PositionDTO position;
     private Instant timestamp;
     
     public GameMoveDTO(String username, PositionDTO position) {
+        this.type = "move";
         this.username = username;
         this.position = position;
         this.timestamp = Instant.now();

--- a/src/test/java/org/arsw/maze_rush/game/dto/GameFinishDTOTest.java
+++ b/src/test/java/org/arsw/maze_rush/game/dto/GameFinishDTOTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 class GameFinishDTOTest {
 
     private static final String USERNAME = "speedRunner";
+    private static final String TYPE = "finish";
     private static final Long FINISH_TIME = 155L; 
     private static final Instant TEST_TIMESTAMP = Instant.parse("2025-10-26T10:00:00Z");
 
@@ -29,8 +30,9 @@ class GameFinishDTOTest {
 
     @Test
     void testAllArgsConstructor() {
-        GameFinishDTO dto = new GameFinishDTO(USERNAME, FINISH_TIME, TEST_TIMESTAMP);
+        GameFinishDTO dto = new GameFinishDTO(TYPE, USERNAME, FINISH_TIME, TEST_TIMESTAMP);
 
+        assertEquals(TYPE, dto.getType());
         assertEquals(USERNAME, dto.getUsername());
         assertEquals(FINISH_TIME, dto.getFinishTime());
         assertEquals(TEST_TIMESTAMP, dto.getTimestamp());
@@ -44,6 +46,7 @@ class GameFinishDTOTest {
         
         Instant after = Instant.now().plus(1, ChronoUnit.SECONDS); 
 
+        assertEquals(TYPE, dto.getType());
         assertEquals(USERNAME, dto.getUsername());
         assertEquals(FINISH_TIME, dto.getFinishTime());
         
@@ -57,8 +60,8 @@ class GameFinishDTOTest {
 
     @Test
     void testEqualsAndHashCodeSameFields() {
-        GameFinishDTO dto1 = new GameFinishDTO(USERNAME, FINISH_TIME, TEST_TIMESTAMP);
-        GameFinishDTO dto2 = new GameFinishDTO(USERNAME, FINISH_TIME, TEST_TIMESTAMP);
+        GameFinishDTO dto1 = new GameFinishDTO(TYPE, USERNAME, FINISH_TIME, TEST_TIMESTAMP);
+        GameFinishDTO dto2 = new GameFinishDTO(TYPE, USERNAME, FINISH_TIME, TEST_TIMESTAMP);
         
         assertEquals(dto1, dto2);
         assertEquals(dto1.hashCode(), dto2.hashCode());
@@ -70,21 +73,21 @@ class GameFinishDTOTest {
 
     @Test
     void testNotEqualsDifferentFields() {
-        GameFinishDTO dtoBase = new GameFinishDTO(USERNAME, FINISH_TIME, TEST_TIMESTAMP);
+        GameFinishDTO dtoBase = new GameFinishDTO(TYPE, USERNAME, FINISH_TIME, TEST_TIMESTAMP);
 
-        GameFinishDTO dtoDiffUser = new GameFinishDTO("otherUser", FINISH_TIME, TEST_TIMESTAMP);
+        GameFinishDTO dtoDiffUser = new GameFinishDTO(TYPE, "otherUser", FINISH_TIME, TEST_TIMESTAMP);
         assertNotEquals(dtoBase, dtoDiffUser);
 
-        GameFinishDTO dtoDiffFinish = new GameFinishDTO(USERNAME, 100L, TEST_TIMESTAMP);
+        GameFinishDTO dtoDiffFinish = new GameFinishDTO(TYPE, USERNAME, 100L, TEST_TIMESTAMP);
         assertNotEquals(dtoBase, dtoDiffFinish);
 
-        GameFinishDTO dtoDiffTime = new GameFinishDTO(USERNAME, FINISH_TIME, TEST_TIMESTAMP.plusSeconds(1));
+        GameFinishDTO dtoDiffTime = new GameFinishDTO(TYPE, USERNAME, FINISH_TIME, TEST_TIMESTAMP.plusSeconds(1));
         assertNotEquals(dtoBase, dtoDiffTime);
     }
 
     @Test
     void testToStringIsCorrect() {
-        GameFinishDTO dto = new GameFinishDTO(USERNAME, FINISH_TIME, TEST_TIMESTAMP);
+        GameFinishDTO dto = new GameFinishDTO(TYPE, USERNAME, FINISH_TIME, TEST_TIMESTAMP);
 
         String result = dto.toString();
         

--- a/src/test/java/org/arsw/maze_rush/game/dto/GameMoveDTOTest.java
+++ b/src/test/java/org/arsw/maze_rush/game/dto/GameMoveDTOTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 class GameMoveDTOTest {
 
     private static final String USERNAME = "movingPlayer";
+    private static final String TYPE = "move";
     private static final Instant testTimeStamp = Instant.parse("2025-10-26T10:00:00Z");
     
     private final PositionDTO testPosition = new PositionDTO(10, 20); 
@@ -31,8 +32,9 @@ class GameMoveDTOTest {
 
     @Test
     void testAllArgsConstructor() {
-        GameMoveDTO dto = new GameMoveDTO(USERNAME, testPosition, testTimeStamp);
+        GameMoveDTO dto = new GameMoveDTO(TYPE, USERNAME, testPosition, testTimeStamp);
 
+        assertEquals(TYPE, dto.getType());
         assertEquals(USERNAME, dto.getUsername());
         assertEquals(testPosition, dto.getPosition());
         assertEquals(testTimeStamp, dto.getTimestamp());
@@ -46,6 +48,7 @@ class GameMoveDTOTest {
         
         Instant after = Instant.now().plus(1, ChronoUnit.SECONDS); 
 
+        assertEquals(TYPE, dto.getType());
         assertEquals(USERNAME, dto.getUsername());
         assertEquals(testPosition, dto.getPosition());
         
@@ -59,8 +62,8 @@ class GameMoveDTOTest {
 
     @Test
     void testEqualsAndHashCodeSameFields() {
-        GameMoveDTO dto1 = new GameMoveDTO(USERNAME, testPosition, testTimeStamp);
-        GameMoveDTO dto2 = new GameMoveDTO(USERNAME, testPosition, testTimeStamp);
+        GameMoveDTO dto1 = new GameMoveDTO(TYPE, USERNAME, testPosition, testTimeStamp);
+        GameMoveDTO dto2 = new GameMoveDTO(TYPE, USERNAME, testPosition, testTimeStamp);
         
         assertEquals(dto1, dto2);
         assertEquals(dto1.hashCode(), dto2.hashCode());
@@ -72,21 +75,21 @@ class GameMoveDTOTest {
 
     @Test
     void testNotEqualsDifferentFields() {
-        GameMoveDTO dtoBase = new GameMoveDTO(USERNAME, testPosition, testTimeStamp);
+        GameMoveDTO dtoBase = new GameMoveDTO(TYPE, USERNAME, testPosition, testTimeStamp);
         
-        GameMoveDTO dtoDiffUser = new GameMoveDTO("otherUser", testPosition, testTimeStamp);
+        GameMoveDTO dtoDiffUser = new GameMoveDTO(TYPE, "otherUser", testPosition, testTimeStamp);
         assertNotEquals(dtoBase, dtoDiffUser);
 
-        GameMoveDTO dtoDiffPos = new GameMoveDTO(USERNAME, anotherPosition, testTimeStamp);
+        GameMoveDTO dtoDiffPos = new GameMoveDTO(TYPE, USERNAME, anotherPosition, testTimeStamp);
         assertNotEquals(dtoBase, dtoDiffPos);
 
-        GameMoveDTO dtoDiffTime = new GameMoveDTO(USERNAME, testPosition, testTimeStamp.plusSeconds(1));
+        GameMoveDTO dtoDiffTime = new GameMoveDTO(TYPE, USERNAME, testPosition, testTimeStamp.plusSeconds(1));
         assertNotEquals(dtoBase, dtoDiffTime);
     }
 
     @Test
     void testToStringIsCorrect() {
-        GameMoveDTO dto = new GameMoveDTO(USERNAME, testPosition, testTimeStamp);
+        GameMoveDTO dto = new GameMoveDTO(TYPE, USERNAME, testPosition, testTimeStamp);
 
         String result = dto.toString();
         


### PR DESCRIPTION
This pull request introduces important enhancements to the player movement handling logic and improves the clarity and consistency of event DTOs for game moves and finishes. The changes allow the server to accept two formats for player movement (direct position or direction-based), and both `GameMoveDTO` and `GameFinishDTO` now explicitly include a `type` field, making event handling and testing more robust.

### Player Movement Handling

* Updated the `handlePlayerMove` method in `GameWebSocketController` to accept two payload formats: direct position updates from the frontend and direction-based movement for advanced logic (e.g., power-ups). The code now checks for a `position` map in the payload and processes it accordingly, falling back to direction/gameId logic if not present. [[1]](diffhunk://#diff-07ba87a5c5aef875dc42c7de9756b0c7ca8d28b8999fcf09409757f8ead2e29fR85-R88) [[2]](diffhunk://#diff-07ba87a5c5aef875dc42c7de9756b0c7ca8d28b8999fcf09409757f8ead2e29fR99-R135)

### DTO Event Type Consistency

* Added a `type` field to both `GameMoveDTO` and `GameFinishDTO`, set to `"move"` and `"finish"` respectively, to clearly identify event types in broadcasts and logs. [[1]](diffhunk://#diff-85ea23dd5dfaf4ab7111be36108933aa95cffd21037d0d80c8fd7296456979e5R16-R22) [[2]](diffhunk://#diff-b43289eac96ca890358c05fb86349b9da9d933ec5fb653ba6a3061c558597f0dR16-R22)

### Test Improvements

* Updated all relevant tests for `GameMoveDTO` and `GameFinishDTO` to include assertions for the new `type` field and to use the new constructor signatures. This ensures correct behavior and equality checks for the DTOs. [[1]](diffhunk://#diff-27a5e8a7a5e99a2b70d82be701282d54936a9c0effaf654ede2fa4ad7c48269eR13) [[2]](diffhunk://#diff-27a5e8a7a5e99a2b70d82be701282d54936a9c0effaf654ede2fa4ad7c48269eL32-R35) [[3]](diffhunk://#diff-27a5e8a7a5e99a2b70d82be701282d54936a9c0effaf654ede2fa4ad7c48269eR49) [[4]](diffhunk://#diff-27a5e8a7a5e99a2b70d82be701282d54936a9c0effaf654ede2fa4ad7c48269eL60-R64) [[5]](diffhunk://#diff-27a5e8a7a5e99a2b70d82be701282d54936a9c0effaf654ede2fa4ad7c48269eL73-R90) [[6]](diffhunk://#diff-fc1b1767be5845f6ea883563e6a46d1f19d6a8e9faf4c7e1100e86637dce83aeR13) [[7]](diffhunk://#diff-fc1b1767be5845f6ea883563e6a46d1f19d6a8e9faf4c7e1100e86637dce83aeL34-R37) [[8]](diffhunk://#diff-fc1b1767be5845f6ea883563e6a46d1f19d6a8e9faf4c7e1100e86637dce83aeR51) [[9]](diffhunk://#diff-fc1b1767be5845f6ea883563e6a46d1f19d6a8e9faf4c7e1100e86637dce83aeL62-R66) [[10]](diffhunk://#diff-fc1b1767be5845f6ea883563e6a46d1f19d6a8e9faf4c7e1100e86637dce83aeL75-R92)