### PR TITLE
fix: test build

### DIFF
--- a/src/test/java/org/arsw/maze_rush/common/logging/LoggingAspectTest.java
+++ b/src/test/java/org/arsw/maze_rush/common/logging/LoggingAspectTest.java
@@ -95,14 +95,14 @@ class LoggingAspectTest {
         when(pjp.getArgs()).thenReturn(new Object[] {});
         when(pjp.proceed()).thenThrow(new IllegalArgumentException("Fail Original"));
 
-        IllegalStateException thrown = assertThrows(IllegalStateException.class, () -> aspect.logMethodExecution(pjp));
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> aspect.logMethodExecution(pjp));
         
-        assertTrue(thrown.getMessage().contains("X Error en"));
-        assertEquals("Fail Original", thrown.getCause().getMessage());
+        assertEquals("Fail Original", thrown.getMessage());
 
         verify(mockLogger, times(1)).debug(anyString(), any(), any(), any());
 
-        verify(mockLogger, never()).error(anyString(), any(Object[].class)); 
+        verify(mockLogger, times(1)).error(eq("X Error en {}.{}() después de {}ms: {} - {}"), 
+            eq("DummyService"), eq("testMethod"), anyLong(), eq("IllegalArgumentException"), eq("Fail Original"));
         verify(mockLogger, never()).warn(anyString(), any(Object[].class));
     }
 

--- a/src/test/java/org/arsw/maze_rush/users/dto/UserRequestDTOTest.java
+++ b/src/test/java/org/arsw/maze_rush/users/dto/UserRequestDTOTest.java
@@ -95,7 +95,7 @@ class UserRequestDTOTest {
         UserRequestDTO dto = new UserRequestDTO();
         
         Set<ConstraintViolation<UserRequestDTO>> violationsNull = validator.validate(dto);
-        assertEquals(0, violationsNull.stream().filter(v -> v.getMessage().contains("no debe estar vacío")).count());
+        assertEquals(3, violationsNull.stream().filter(v -> v.getMessage().contains("no debe estar vacío")).count());
 
         dto.setUsername("");
         dto.setEmail("");


### PR DESCRIPTION
This pull request updates unit tests to improve validation coverage and correct exception handling assertions. The most significant changes are in the test logic for logging aspect exception paths and user request DTO validation.

**Testing and validation improvements:**

* In `UserRequestDTOTest.java`, the test for blank and null fields now expects three validation errors for missing required fields, instead of zero, ensuring proper validation of empty fields.

**Exception handling and logging assertions:**

* In `LoggingAspectTest.java`, the test for exception paths now asserts that an `IllegalArgumentException` is thrown (not `IllegalStateException`), and verifies the exception message directly. The logging assertions have also been updated to check that the error log is called with the correct parameters, reflecting the thrown exception and message.